### PR TITLE
Add specific error handling for JSON parsing.

### DIFF
--- a/validation/validate.py
+++ b/validation/validate.py
@@ -95,7 +95,14 @@ def read_questionnaires():
     files = glob.glob(QUESTIONNAIRE_GLOB)
     for fname in files:
         with open(fname) as f:
-            read_questionnaire(fname.split("/")[-1], json.load(f), question_codes)
+            try:
+                parsed_json = json.load(f)
+            except ValueError, e:
+                print (
+                    'Failed to parse JSON in %r. To debug, run:\n'
+                    '\tpython -m json.tool < %s') % (fname, fname)
+                raise
+            read_questionnaire(fname.split("/")[-1], parsed_json, question_codes)
     return question_codes
 
 codebook_codes = read_codebook()


### PR DESCRIPTION
Before:

```
validation$ python validate.py 
Evaluating Questionnaire against current codebook version: 0.2.71

Traceback (most recent call last):
  File "validate.py", line 102, in <module>
    questionnaire_codes = read_questionnaires()
  File "validate.py", line 98, in read_questionnaires
    read_questionnaire(fname.split("/")[-1], json.load(f), question_codes)
  File "/usr/lib/python2.7/json/__init__.py", line 290, in load
    **kw)
  File "/usr/lib/python2.7/json/__init__.py", line 338, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 369, in decode
    raise ValueError(errmsg("Extra data", s, end, len(s)))
ValueError: Extra data: line 181 column 1 - line 182 column 1 (char 6217 - 6220)
```

After:

```
validation$ python validate.py 
Evaluating Questionnaire against current codebook version: 0.2.71

Failed to parse JSON in '../questionnaire_payloads/post_pmb_feedback.json'. To debug, run:
	python -m json.tool < ../questionnaire_payloads/post_pmb_feedback.json
Traceback (most recent call last):
  File "validate.py", line 109, in <module>
    questionnaire_codes = read_questionnaires()
  File "validate.py", line 99, in read_questionnaires
    parsed_json = json.load(f)
  File "/usr/lib/python2.7/json/__init__.py", line 290, in load
    **kw)
  File "/usr/lib/python2.7/json/__init__.py", line 338, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 369, in decode
    raise ValueError(errmsg("Extra data", s, end, len(s)))
ValueError: Extra data: line 181 column 1 - line 182 column 1 (char 6217 - 6220)
validation$ python -m json.tool < ../questionnaire_payloads/post_pmb_feedback.json
Extra data: line 181 column 1 - line 182 column 1 (char 6217 - 6220)
```